### PR TITLE
Remove TTY Requirement

### DIFF
--- a/Sources/Bedrockifier/Extensions/StringExtensions.swift
+++ b/Sources/Bedrockifier/Extensions/StringExtensions.swift
@@ -17,29 +17,29 @@ func parse(ownership: String) throws -> (UInt?, UInt?) {
     if ownership == ":" {
         return (nil, nil)
     }
-    
+
     let parts = ownership.split(separator: ":")
     guard parts.count < 3 else {
         throw ParseError.invalidSyntax
     }
-    
+
     let intParts = parts.map({ UInt($0) })
     guard !intParts.contains(nil) else {
         throw ParseError.invalidSyntax
     }
-    
+
     let finalParts = intParts.compactMap({ $0 })
-    
+
     // Special Case: Group Only
     if finalParts.count == 1 && ownership.starts(with: ":") {
         return (nil, finalParts[0])
     }
-    
+
     // Special Case: Onwer Only
     if finalParts.count == 1 {
         return (finalParts[0], nil)
     }
-    
+
     return (finalParts[0], finalParts[1])
 }
 
@@ -47,10 +47,10 @@ func parse(permissions: String) throws -> UInt {
     guard let permissionValue = UInt(permissions) else {
         throw ParseError.invalidSyntax
     }
-    
+
     guard permissionValue <= 777 else {
         throw ParseError.outOfBounds
     }
-    
+
     return permissionValue
 }

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -15,7 +15,7 @@ struct BackupConfig: Codable {
         var keepDays: Int?
         var minKeep: Int?
     }
-    
+
     struct OwnershipConfig: Codable {
         var chown: String?
         var permissions: String?
@@ -45,7 +45,7 @@ extension BackupConfig.OwnershipConfig {
         guard let chownString = self.chown else { return (nil, nil) }
         return try parse(ownership: chownString)
     }
-    
+
     func parsePosixPermissions() throws -> UInt? {
         guard let permissionsString = self.permissions else { return nil }
         return try parse(permissions: permissionsString)

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -60,10 +60,14 @@ extension WorldBackup {
             // Detach from Container
             if usePty {
                 try? process.send("Q")
+                process.waitUntilExit()
             } else {
                 process.terminate()
             }
-            process.waitUntilExit()
+
+            if process.isRunning {
+                print("Docker attach process is still running")
+            }
         }
 
         // Start Save Hold

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -48,7 +48,7 @@ extension WorldBackup {
             ]
         }
     }
-    
+
     static func makeBackup(backupUrl: URL, dockerPath: String, containerName: String, worldsPath: URL) throws {
         let arguments: [String] = getPtyArguments(dockerPath: dockerPath, containerName: containerName)
 

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -6,9 +6,11 @@
 //
 
 import Foundation
+import Logging
 import PTYKit
 
-let usePty = false
+fileprivate let usePty = false
+fileprivate let logger = Logger(label: "BedrockifierCLI:WorldBackup")
 
 class WorldBackup {
     enum Action {
@@ -59,14 +61,16 @@ extension WorldBackup {
         defer {
             // Detach from Container
             if usePty {
+                logger.debug("Detaching Docker Process")
                 try? process.send("Q")
                 process.waitUntilExit()
             } else {
+                logger.debug("Terminating Docker Process")
                 process.terminate()
             }
 
             if process.isRunning {
-                print("Docker attach process is still running")
+                logger.error("Docker Process Still Running")
             }
         }
 

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -45,9 +45,19 @@ extension WorldBackup {
         } else {
             // Without a tty, use a termination signal instead
             return [
-                "-c",
-                "\(dockerPath) attach --sig-proxy=false \(containerName)"
+                "attach",
+                "--sig-proxy=false",
+                containerName
             ]
+        }
+    }
+
+    static func getPtyProcess(dockerPath: String) -> URL {
+        if usePty {
+            // Use a shell for the tty capability
+            return URL(fileURLWithPath: "/bin/sh")
+        } else {
+            return URL(fileURLWithPath: dockerPath)
         }
     }
 
@@ -55,7 +65,7 @@ extension WorldBackup {
         let arguments: [String] = getPtyArguments(dockerPath: dockerPath, containerName: containerName)
 
         // Attach To Container
-        let process = try PTYProcess(URL(fileURLWithPath: "/bin/sh"), arguments: arguments)
+        let process = try PTYProcess(getPtyProcess(dockerPath: dockerPath), arguments: arguments)
         try process.run()
 
         defer {

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -77,6 +77,7 @@ extension WorldBackup {
             } else {
                 logger.debug("Terminating Docker Process")
                 process.terminate()
+                process.waitUntilExit()
             }
 
             if process.isRunning {


### PR DESCRIPTION
Removes the need to enable tty on the Minecraft server, and no longer needs to execute `docker attach` in a shell.

It still works with tty enabled, but no longer requires it. So this is going to be more reliable in the long run.

Resolves issue: https://github.com/Kaiede/docker-minecraft-bedrock-backup/issues/12
