### PR TITLE
Add Java Support

### DIFF
--- a/Sources/Bedrockifier/Commands/BackupJobCommand.swift
+++ b/Sources/Bedrockifier/Commands/BackupJobCommand.swift
@@ -79,13 +79,7 @@ public final class BackupJobCommand: Command {
                 let backupUrl = URL(fileURLWithPath: backupPath)
 
                 Library.log.info("Performing Backups")
-                for (serverContainer, serverWorldsPath) in config.servers {
-                    let worldsUrl = URL(fileURLWithPath: serverWorldsPath)
-                    try await WorldBackup.makeBackup(backupUrl: backupUrl,
-                                               dockerPath: dockerPath,
-                                               containerName: serverContainer,
-                                               worldsPath: worldsUrl)
-                }
+                try await WorldBackup.runBackups(config: config, destination: backupUrl, dockerPath: dockerPath)
 
                 if let ownershipConfig = config.ownership {
                     Library.log.info("Performing Ownership Fixup")

--- a/Sources/Bedrockifier/Commands/UnpackCommand.swift
+++ b/Sources/Bedrockifier/Commands/UnpackCommand.swift
@@ -46,7 +46,7 @@ public final class UnpackCommand: Command {
     public func run(using context: CommandContext, signature: Signature) throws {
         do {
             let world = try World(url: URL(fileURLWithPath: signature.mcworld))
-            guard world.type == .mcworld else {
+            guard world.type != .folder else {
                 context.console.error("Input was not an mcworld")
                 return
             }

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -57,8 +57,8 @@ public struct BackupConfig: Codable {
     }
 
     public struct ServerContainersConfig: Codable {
-        public var java: [ContainerConfig]
-        public var bedrock: [ContainerConfig]
+        public var java: [ContainerConfig]?
+        public var bedrock: [ContainerConfig]?
     }
 
     public var dockerPath: String?

--- a/Sources/Bedrockifier/Model/BackupConfig.swift
+++ b/Sources/Bedrockifier/Model/BackupConfig.swift
@@ -51,9 +51,20 @@ public struct BackupConfig: Codable {
         case trace
     }
 
+    public struct ContainerConfig: Codable {
+        public var name: String
+        public var worlds: [String]
+    }
+
+    public struct ServerContainersConfig: Codable {
+        public var java: [ContainerConfig]
+        public var bedrock: [ContainerConfig]
+    }
+
     public var dockerPath: String?
     public var backupPath: String?
-    public var servers: ServerConfig
+    public var servers: ServerConfig?
+    public var containers: ServerContainersConfig?
     public var trim: TrimConfig?
     public var ownership: OwnershipConfig?
     public var schedule: ScheduleConfig?
@@ -69,24 +80,7 @@ extension BackupConfig {
     public static func getBackupConfig(from data: Data) throws -> BackupConfig {
         let decodey = YAMLDecoder()
         let config = try decodey.decode(BackupConfig.self, from: data)
-        try config.validate(requireSchedule: false)
         return config
-    }
-}
-
-extension BackupConfig {
-    func validate(requireSchedule: Bool) throws {
-        if requireSchedule {
-            guard let schedule = self.schedule else {
-                return // TODO: Throw Missing Schedule
-            }
-
-            if schedule.interval == nil && schedule.onPlayerLogin != true && schedule.onPlayerLogout != true {
-                return // TODO: Throw needs at at least one schedule type
-            }
-
-            // TODO: Validate interval
-        }
     }
 }
 

--- a/Sources/Bedrockifier/Model/World.swift
+++ b/Sources/Bedrockifier/Model/World.swift
@@ -25,7 +25,6 @@
 
 import Foundation
 import Logging
-import System
 import ZIPFoundation
 
 struct World {
@@ -160,9 +159,9 @@ extension World {
         let dirEnum = FileManager.default.enumerator(atPath: self.location.path)
 
 
-        let folderBase = FilePath(self.location.lastPathComponent)
+        let folderBase = NSString(string: self.location.lastPathComponent)
         while let archiveItem = dirEnum?.nextObject() as? String {
-            let archivePath = folderBase.appending(archiveItem).string
+            let archivePath = String(folderBase.appendingPathComponent(archiveItem))
             let fullItemUrl = URL(fileURLWithPath: archiveItem, relativeTo: self.location)
             try archive.addEntry(with: archivePath, fileURL: fullItemUrl)
         }

--- a/Sources/Bedrockifier/Model/WorldBackup.swift
+++ b/Sources/Bedrockifier/Model/WorldBackup.swift
@@ -204,8 +204,9 @@ extension WorldBackup {
     }
 
     private static func pauseSaveOnJava(process: PTYProcess) async throws {
+        // Need a longer timeout on the flush in case server is still starting up
         try process.sendLine("save-all flush")
-        if await process.expect(["Saved the game"], timeout: 10.0) == .noMatch {
+        if await process.expect(["Saved the game"], timeout: 30.0) == .noMatch {
             throw WorldBackupError.holdFailed
         }
 

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -59,7 +59,7 @@ struct Server: ParsableCommand {
             return
         }
 
-        guard let config = try? BackupConfig.getBackupConfig(from: configUri) else {
+        guard let config = try? getConfig(from: configUri) else {
             Server.logger.error("Unable to read configuration file, fix the above errors and try again")
             return
         }
@@ -99,6 +99,16 @@ struct Server: ParsableCommand {
 
         // Start Event Loop
         dispatchMain()
+    }
+
+    private func getConfig(from configUri: URL) throws -> BackupConfig {
+        do {
+            Server.logger.info("Loading Configuration From: \(configUri.path)")
+            return try BackupConfig.getBackupConfig(from: configUri)
+        } catch let error {
+            Server.logger.error("\(error)")
+            throw error
+        }
     }
 
     private func getConfigFileUrl(environment: EnvironmentConfig) -> URL {

--- a/Sources/Service/main.swift
+++ b/Sources/Service/main.swift
@@ -159,13 +159,7 @@ struct Server: ParsableCommand {
     private static func runBackup(config: BackupConfig, backupUrl: URL, dockerPath: String) async {
         Server.logger.info("Starting Backup")
         do {
-            for (serverContainer, serverWorldsPath) in config.servers {
-                let worldsUrl = URL(fileURLWithPath: serverWorldsPath)
-                try await WorldBackup.makeBackup(backupUrl: backupUrl,
-                                           dockerPath: dockerPath,
-                                           containerName: serverContainer,
-                                           worldsPath: worldsUrl)
-            }
+            try await WorldBackup.runBackups(config: config, destination: backupUrl, dockerPath: dockerPath)
 
             if let ownershipConfig = config.ownership {
                 Server.logger.info("Performing Ownership Fixup")

--- a/Tests/BedrockifierTests/BackupConfigJsonTests.swift
+++ b/Tests/BedrockifierTests/BackupConfigJsonTests.swift
@@ -12,7 +12,7 @@ final class BackupConfigJsonTests: XCTestCase {
             let config = try BackupConfig.getBackupConfig(from: jsonData)
             XCTAssertNil(config.backupPath)
             XCTAssertNil(config.dockerPath)
-            XCTAssertEqual(config.servers.count, 2)
+            XCTAssertEqual(config.servers?.count, 2)
             XCTAssertNil(config.trim)
             XCTAssertNil(config.loggingLevel)
         } catch(let error) {
@@ -30,7 +30,7 @@ final class BackupConfigJsonTests: XCTestCase {
             let config = try BackupConfig.getBackupConfig(from: jsonData)
             XCTAssertNil(config.backupPath)
             XCTAssertNil(config.dockerPath)
-            XCTAssertEqual(config.servers.count, 2)
+            XCTAssertEqual(config.servers?.count, 2)
             XCTAssertNotNil(config.trim)
         } catch(let error) {
             XCTFail("Unable to decode valid JSON: \(error)")
@@ -47,7 +47,7 @@ final class BackupConfigJsonTests: XCTestCase {
             let config = try BackupConfig.getBackupConfig(from: jsonData)
             XCTAssertNotNil(config.backupPath)
             XCTAssertNotNil(config.dockerPath)
-            XCTAssertEqual(config.servers.count, 2)
+            XCTAssertEqual(config.servers?.count, 2)
             XCTAssertNotNil(config.trim)
             XCTAssertEqual(config.loggingLevel, .debug)
         } catch(let error) {
@@ -96,6 +96,40 @@ final class BackupConfigJsonTests: XCTestCase {
             XCTAssertEqual(scheduleConfig.onPlayerLogout, nil)
         } catch(let error) {
             XCTFail("Unable to decode valid JSON: \(error)")
+        }
+    }
+
+    func testModernContainerConfig() {
+        guard let data = modernContainersJsonConfigString.data(using: .utf8) else {
+            XCTFail("couldn't get test data")
+            return
+        }
+
+        do {
+            let config = try BackupConfig.getBackupConfig(from: data)
+
+            XCTAssertNil(config.servers)
+            guard let javaContainers = config.containers?.java else {
+                XCTFail("Java containers should decode")
+                return
+            }
+
+            guard let bedrockContainers = config.containers?.bedrock else {
+                XCTFail("Bedrock containers should decode")
+                return
+            }
+
+            XCTAssertEqual(javaContainers.count, 1)
+            XCTAssertEqual(javaContainers[0].name, "minecraft_java")
+            XCTAssertEqual(javaContainers[0].worlds, ["/java/TheWorld"])
+
+
+            XCTAssertEqual(bedrockContainers.count, 1)
+            XCTAssertEqual(bedrockContainers[0].name, "minecraft_bedrock")
+            XCTAssertEqual(bedrockContainers[0].worlds, ["/bedrock/worlds/FirstWorld", "/bedrock/worlds/SecondWorld"])
+
+        } catch(let error) {
+            XCTFail("Unable to decode valid config: \(error)")
         }
     }
 
@@ -181,6 +215,38 @@ let scheduleJsonConfigString = """
         "schedule": {
             "interval": "3h",
             "onPlayerLogin": true
+        },
+        "trim": {
+            "trimDays":   2,
+            "keepDays":   14,
+            "minKeep":    2
+        }
+    }
+    """
+
+let modernContainersJsonConfigString = """
+    {
+        "dockerPath": "/usr/bin/docker",
+        "backupPath": "/backups",
+        "loggingLevel": "debug",
+        "containers": {
+            "bedrock": [
+                {
+                    "name": "minecraft_bedrock",
+                    "worlds": [
+                        "/bedrock/worlds/FirstWorld",
+                        "/bedrock/worlds/SecondWorld"
+                    ]
+                }
+            ],
+            "java": [
+                {
+                    "name": "minecraft_java",
+                    "worlds": [
+                        "/java/TheWorld"
+                    ]
+                }
+            ]
         },
         "trim": {
             "trimDays":   2,

--- a/Tests/BedrockifierTests/BackupConfigYamlTests.swift
+++ b/Tests/BedrockifierTests/BackupConfigYamlTests.swift
@@ -101,6 +101,32 @@ final class BackupConfigYamlTests: XCTestCase {
         }
     }
 
+    func testModernContainerPartialConfig() {
+        guard let data = modernContainersPartialYamlConfigString.data(using: .utf8) else {
+            XCTFail("couldn't get test data")
+            return
+        }
+
+        do {
+            let config = try BackupConfig.getBackupConfig(from: data)
+
+            XCTAssertNil(config.servers)
+            XCTAssertNil(config.containers?.java)
+
+            guard let bedrockContainers = config.containers?.bedrock else {
+                XCTFail("Bedrock containers should decode")
+                return
+            }
+
+            XCTAssertEqual(bedrockContainers.count, 1)
+            XCTAssertEqual(bedrockContainers[0].name, "minecraft_bedrock")
+            XCTAssertEqual(bedrockContainers[0].worlds, ["/bedrock/worlds/FirstWorld", "/bedrock/worlds/SecondWorld"])
+
+        } catch(let error) {
+            XCTFail("Unable to decode valid config: \(error)")
+        }
+    }
+
     func testModernContainerConfig() {
         guard let data = modernContainersYamlConfigString.data(using: .utf8) else {
             XCTFail("couldn't get test data")
@@ -199,6 +225,22 @@ let scheduleYamlConfigString = """
     schedule:
         interval: 3h
         onPlayerLogin: true
+    trim:
+        trimDays: 2
+        keepDays: 14
+        minKeep: 2
+    """
+
+let modernContainersPartialYamlConfigString = """
+    dockerPath: /usr/bin/docker
+    backupPath: /backups
+    loggingLevel: trace
+    containers:
+        bedrock:
+            - name: minecraft_bedrock
+              worlds:
+                - /bedrock/worlds/FirstWorld
+                - /bedrock/worlds/SecondWorld
     trim:
         trimDays: 2
         keepDays: 14


### PR DESCRIPTION
Adds Java support to the service, allowing it to be run against itgz's Minecraft docker server, not just Bedrock. 

Includes updated configuration tweaks around supporting a new structure for specifying Java and Bedrock servers to be backed up. One backup container can backup any number of Java and/or Bedrock containers. 